### PR TITLE
Frontend User-Post Connection  

### DIFF
--- a/frontend/src/api/UserApi.js
+++ b/frontend/src/api/UserApi.js
@@ -1,0 +1,9 @@
+import Api from "./Api";
+
+class UserApi {
+  getUser() {
+    return Api.get("/users");
+  }
+}
+
+export default new UserApi();

--- a/frontend/src/components/posts/PostCard.jsx
+++ b/frontend/src/components/posts/PostCard.jsx
@@ -6,12 +6,14 @@ import CommentForm from "../comments/CommentForm";
 import CommentList from "../comments/CommentList";
 import CommentsApi from "../../api/CommentsApi";
 import PostsApi from "../../api/PostsApi";
+import UserApi from "../../api/UserApi";
 import PostUpdateForm from "./PostUpdateForm";
 
 export default function PostCard({ post, onDeleteClick }) {
   // Local state
   const [comments, setComments] = useState([]);
   const [toggleUpdatePost, setToggleUpdatePost] = useState(false);
+  const [user, setUser] = useState({});
 
   // Constants
   const postId = post.id;
@@ -53,6 +55,14 @@ export default function PostCard({ post, onDeleteClick }) {
       .then(({ data }) => setComments(data))
       .catch((err) => console.error(err));
   }, [setComments, postId]);
+
+  useEffect(() => {
+    UserApi.getUser()
+      .then(({ data }) => {
+        setUser(data);
+      })
+      .catch((err) => console.error(err));
+  }, [setUser]);
 
   return (
     <div>

--- a/frontend/src/components/posts/PostCard.jsx
+++ b/frontend/src/components/posts/PostCard.jsx
@@ -17,6 +17,8 @@ export default function PostCard({ post, onDeleteClick }) {
 
   // Constants
   const postId = post.id;
+  const postCreatorName = post.relatedUser.name;
+  const postCreatorEmail = post.relatedUser.email;
 
   // Methods
   async function updatePost(updatedPost) {
@@ -51,7 +53,7 @@ export default function PostCard({ post, onDeleteClick }) {
   }
 
   function checkUserEmail() {
-    if (post.relatedUser.email === user.email) {
+    if (postCreatorEmail === user.email) {
       return true;
     }
     return false;
@@ -74,7 +76,9 @@ export default function PostCard({ post, onDeleteClick }) {
   return (
     <div>
       <div>
-        <p>{post.relatedUser.name}: {post.contentText}</p>
+        <p>
+          {postCreatorName}: {post.contentText}
+        </p>
         {checkUserEmail() && (
           <div>
             <button onClick={onDeleteClick}>Delete</button>

--- a/frontend/src/components/posts/PostCard.jsx
+++ b/frontend/src/components/posts/PostCard.jsx
@@ -50,6 +50,13 @@ export default function PostCard({ post, onDeleteClick }) {
     }
   }
 
+  function checkUserEmail() {
+    if (post.relatedUser.email === user.email) {
+      return true;
+    }
+    return false;
+  }
+
   useEffect(() => {
     CommentsApi.getAllComments(postId)
       .then(({ data }) => setComments(data))
@@ -67,22 +74,26 @@ export default function PostCard({ post, onDeleteClick }) {
   return (
     <div>
       <div>
-        <p>{post.contentText}</p>
-        <button onClick={onDeleteClick}>Delete</button>
-        <button
-          onClick={() =>
-            toggleUpdatePost
-              ? setToggleUpdatePost(false)
-              : setToggleUpdatePost(true)
-          }
-        >
-          {toggleUpdatePost ? "Cancel Update" : "Update"}
-        </button>
-        {toggleUpdatePost && (
-          <PostUpdateForm
-            onSubmit={(postData) => updatePost(postData)}
-            post={post}
-          />
+        <p>{post.relatedUser.name}: {post.contentText}</p>
+        {checkUserEmail() && (
+          <div>
+            <button onClick={onDeleteClick}>Delete</button>
+            <button
+              onClick={() =>
+                toggleUpdatePost
+                  ? setToggleUpdatePost(false)
+                  : setToggleUpdatePost(true)
+              }
+            >
+              {toggleUpdatePost ? "Cancel Update" : "Update"}
+            </button>
+            {toggleUpdatePost && (
+              <PostUpdateForm
+                onSubmit={(postData) => updatePost(postData)}
+                post={post}
+              />
+            )}
+          </div>
         )}
         <CommentList
           postId={postId}


### PR DESCRIPTION
# Changes proposed in this pull request
- Adds UserName of a post creator before content.
- Hides Update and Delete buttons of a post when current user is not the owner.