### PR TITLE
fix bug - accountType dropdown shows existing type

### DIFF
--- a/frontend/src/components/profile/ProfileForm.jsx
+++ b/frontend/src/components/profile/ProfileForm.jsx
@@ -61,7 +61,7 @@ export default function ProfileForm({
             <label className="field-label">I'm a</label>
             <select
               className="select-profile"
-              selected={accountType}
+              value={accountType}
               onChange={(e) => setAccountType(e.target.value)}
             >
               <option value="pet">pet</option>


### PR DESCRIPTION
# Changes proposed

- Fix bug: ProfileForm now displays the existing accountType in select dropdown

![Screenshot 2021-05-13 at 11 09 32](https://user-images.githubusercontent.com/46404690/118104874-fd12a780-b3db-11eb-8749-84eec59abba0.png)
